### PR TITLE
feat: 日付機能の統合とUI改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
                 <div class="memo-controls">
                     <button class="btn btn-success" onclick="newMemo()">新規メモ</button>
                     <button class="btn btn-secondary" onclick="clearMemo()">クリア</button>
-                    <button class="btn" onclick="copyFromTemplate()">テンプレートを日付付きでコピー</button>
+                    <button class="btn" onclick="copyFromTemplate()">テンプレートからコピー</button>
                     <button class="btn" onclick="addDateToMemo()">メモ内容に日付を付加する</button>
                     <button class="btn btn-primary" onclick="copyToClipboard()">📋 クリップボードにコピー</button>
                 </div>

--- a/js/app.js
+++ b/js/app.js
@@ -114,23 +114,9 @@ function copyFromTemplate() {
         return;
     }
     
-    const now = new Date();
-    const dateStr = now.getFullYear() + '/' + 
-                   String(now.getMonth() + 1).padStart(2, '0') + '/' + 
-                   String(now.getDate()).padStart(2, '0');
-    const timeStr = String(now.getHours()).padStart(2, '0') + ':' + 
-                   String(now.getMinutes()).padStart(2, '0');
-    
-    let templateContent = templates[selectedTemplate];
-    
-    // yyyy/mm/dd形式の文言を当日日付で置換
-    templateContent = templateContent.replace(/\d{4}\/\d{2}\/\d{2}/g, dateStr);
-    
-    // 現在日時を付加してコピー
-    const newContent = `${dateStr} ${timeStr}\n\n${templateContent}`;
-    
-    document.getElementById('memoText').value = newContent;
-    alert('テンプレートをコピーしました（現在日時付き）');
+    const templateContent = templates[selectedTemplate];
+    document.getElementById('memoText').value = templateContent;
+    alert('テンプレートをコピーしました');
 }
 
 function addDateToMemo() {
@@ -138,6 +124,8 @@ function addDateToMemo() {
     const dateStr = now.getFullYear() + '/' + 
                    String(now.getMonth() + 1).padStart(2, '0') + '/' + 
                    String(now.getDate()).padStart(2, '0');
+    const timeStr = String(now.getHours()).padStart(2, '0') + ':' + 
+                   String(now.getMinutes()).padStart(2, '0');
     
     const memoTextArea = document.getElementById('memoText');
     let currentContent = memoTextArea.value;
@@ -151,12 +139,15 @@ function addDateToMemo() {
     const updatedContent = currentContent.replace(/yyyy\/mm\/dd/g, dateStr);
     
     if (updatedContent === currentContent) {
-        alert('yyyy/mm/dd の形式が見つかりませんでした');
-        return;
+        // yyyy/mm/ddが見つからない場合は、先頭に日付・時刻を付加
+        const finalContent = `${dateStr} ${timeStr}\n\n${currentContent}`;
+        memoTextArea.value = finalContent;
+        alert('先頭に日付・時刻を追加しました: ' + dateStr + ' ' + timeStr);
+    } else {
+        // yyyy/mm/ddが見つかった場合は置換のみ
+        memoTextArea.value = updatedContent;
+        alert('yyyy/mm/dd を日付に置換しました: ' + dateStr);
     }
-    
-    memoTextArea.value = updatedContent;
-    alert('日付を更新しました: ' + dateStr);
 }
 
 function newMemo() {


### PR DESCRIPTION
## Summary
- 「メモ内容に日付を付加する」機能を拡張・統合
- テンプレートコピー機能の簡素化
- より直感的で柔軟な日付機能を実現

## 主な変更点

### 統合された日付付加機能
**動作パターン:**
1. **yyyy/mm/dd が含まれている場合** → その位置に当日日付を置換
2. **yyyy/mm/dd が含まれていない場合** → 先頭に日付・時刻を付加

### テンプレートコピー機能の簡素化
- 日付付加機能を分離し、純粋なテンプレートコピー機能に戻す
- ボタン名称: 「テンプレートを日付付きでコピー」→「テンプレートからコピー」

### 使用例
```
# パターン1: yyyy/mm/dd置換
入力: "会議は yyyy/mm/dd に開催"
結果: "会議は 2025/09/06 に開催"

# パターン2: 先頭に日付・時刻付加
入力: "今日の議事録"
結果: "2025/09/06 17:30\n\n今日の議事録"
```

## Test plan
- [x] メモに「会議は yyyy/mm/dd です」→ 日付置換動作確認
- [x] メモに「普通の文章」→ 先頭に日付・時刻付加確認  
- [x] テンプレートコピーが純粋なコピーとして動作確認
- [x] 既存機能（新規メモ、クリップボードコピー等）の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)