### PR TITLE
fix: mm/ddリテラル置換対応とclaude.mdルール強化

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -446,3 +446,44 @@ cp ./CLAUDE.md "C:/develop/CLAUDE.md"
 禁止事項: 余計なライブラリ追加 仕様の独断変更
 ```
 
+---
+
+## ルール遵守の徹底
+
+### 必須チェック項目（作業開始前）
+- [ ] `claude.md` を読み直した
+- [ ] 影響範囲を洗い出した
+- [ ] 修正ブランチを作成した
+- [ ] 対応後の確認方法を決めた
+
+### 修正ブランチ運用の強制
+**原則**: すべての修正は修正ブランチで行い、プルリクエスト経由でmasterにマージする
+
+```bash
+# 修正ブランチ作成・切り替え
+git checkout -b fix/issue-description
+
+# 修正作業実施
+# ...
+
+# コミット・プッシュ
+git add .
+git commit -m "fix: 修正内容の説明"
+git push origin fix/issue-description
+
+# プルリクエスト作成
+gh pr create --title "修正タイトル" --body "修正内容の詳細"
+
+# マージ後にブランチ削除
+git checkout master
+git pull origin master
+git branch -d fix/issue-description
+```
+
+### 違反した場合の対応
+1. 作業を一時停止
+2. claude.mdを読み直し
+3. 違反内容を明確化
+4. 必要に応じて作業をやり直し
+5. 今後の再発防止策を検討
+

--- a/js/app.js
+++ b/js/app.js
@@ -138,7 +138,10 @@ function addDateToMemo() {
     
     // mm/dd形式の日付を当日の月/日で置換（0埋めなし）
     const monthDay = String(now.getMonth() + 1) + '/' + String(now.getDate());
-    const mmddReplaced = currentContent.replace(/\b\d{1,2}\/\d{1,2}\b/g, monthDay);
+    // mm/ddのリテラル文字列も含めて置換対象とする
+    let mmddReplaced = currentContent.replace(/\bmm\/dd\b/g, monthDay);
+    // 数字のmm/dd形式も置換
+    mmddReplaced = mmddReplaced.replace(/\b\d{1,2}\/\d{1,2}\b/g, monthDay);
     
     // メモ内容のyyyy/mm/dd形式を当日日付で置換
     let updatedContent = mmddReplaced.replace(/yyyy\/mm\/dd/g, dateStr);


### PR DESCRIPTION
## Summary
- mm/ddリテラル文字列（「mm/dd」）の置換機能を追加
- claude.mdにルール遵守の徹底セクションを追加し、親フォルダと同期

## 修正内容
### mm/dd置換バグ修正
- リテラル文字列「mm/dd」が正規表現の対象外だった問題を修正
- `/\bmm\/dd\b/g` で明示的にリテラル置換を追加
- 数値形式（3/7など）と併用可能

### claude.mdルール強化
- 必須チェック項目（作業開始前）を明文化
- 修正ブランチ運用の強制化
- 違反時の対応手順を追加

## Test plan
- [x] 「mm/dd」リテラル文字列の置換動作確認
- [x] 数値mm/dd形式（3/7等）との併用確認
- [x] 置換成功時の先頭日付付加回避確認
- [x] claude.md同期確認

## 影響範囲
- addDateToMemo関数の置換ロジック追加
- claude.mdルール追加（破壊的変更なし）

🤖 Generated with [Claude Code](https://claude.ai/code)