### PR TITLE
fix: oldpjt/フォルダを.gitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ temp/
 *~
 \#*\#
 .\#*
+
+# Old project files - 旧プロジェクトファイル
+oldpjt/


### PR DESCRIPTION
## 目的
旧プロジェクトファイルをGit管理対象外にする

## 変更内容
- .gitignoreにoldpjt/フォルダを追加
- 「# Old project files - 旧プロジェクトファイル」コメントを追加

## Before / After
**Before**: oldpjt/フォルダがGit管理対象に含まれていた
**After**: oldpjt/フォルダがGit管理対象外になった

## 影響範囲
- 既存の機能への影響なし
- oldpjt/フォルダ配下のファイルがgit statusに表示されなくなる

## テスト内容
- .gitignoreファイルの内容確認
- git statusでoldpjt/が表示されないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)