### PR TITLE
fix: 日付付加ボタンから時間削除とテンプレート表示件数増加

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -175,7 +175,7 @@ textarea:focus {
 }
 
 .template-list {
-    max-height: 300px;
+    max-height: 500px;
     overflow-y: auto;
     border: 2px solid var(--border-purple);
     border-radius: 12px;

--- a/js/app.js
+++ b/js/app.js
@@ -422,11 +422,9 @@ function deleteTemplate() {
 
 function addDateToMemo() {
     const now = new Date();
-    const dateStr = now.getFullYear() + '/' + 
-                   String(now.getMonth() + 1).padStart(2, '0') + '/' + 
+    const dateStr = now.getFullYear() + '/' +
+                   String(now.getMonth() + 1).padStart(2, '0') + '/' +
                    String(now.getDate()).padStart(2, '0');
-    const timeStr = String(now.getHours()).padStart(2, '0') + ':' + 
-                   String(now.getMinutes()).padStart(2, '0');
     
     const memoTextArea = document.getElementById('memoText');
     let currentContent = memoTextArea.value;
@@ -461,10 +459,10 @@ function addDateToMemo() {
             // 既存の日付がある場合は何もしない
             alert('既存の日付が検出されたため、日付の追加は行いません');
         } else {
-            // 日付がない場合のみ、先頭に日付・時刻を付加
-            const finalContent = `${dateStr} ${timeStr}\n\n${currentContent}`;
+            // 日付がない場合のみ、先頭に日付を付加
+            const finalContent = `${dateStr}\n\n${currentContent}`;
             memoTextArea.value = finalContent;
-            alert('先頭に日付・時刻を追加しました: ' + dateStr + ' ' + timeStr);
+            alert('先頭に日付を追加しました: ' + dateStr);
         }
     }
 }


### PR DESCRIPTION
## 修正内容

### 1. 日付付加ボタンの時間付与削除
- **Before**: 日付付加時に時間も一緒に付与
- **After**: 日付のみ付与（時間削除）

### 2. テンプレート表示窓の表示件数増加
- **Before**: max-height: 300px（3個程度表示）
- **After**: max-height: 500px（5-6個表示）

## 影響範囲
- `js/app.js`: addDateToMemo()関数の時間付与処理削除
- `css/style.css`: .template-listのmax-height変更

## テスト確認項目
- [ ] 日付付加ボタンで時間が付与されないこと
- [ ] テンプレート一覧で5-6個のテンプレートが表示されること
- [ ] 既存の日付置換機能が正常動作すること

🤖 Generated with [Claude Code](https://claude.ai/code)