### PR TITLE
fix: テンプレートボックス日付付与ボタンから時間削除

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -249,8 +249,6 @@ function addDateToTemplateBox(templateName) {
     const dateStr = now.getFullYear() + '/' +
                    String(now.getMonth() + 1).padStart(2, '0') + '/' +
                    String(now.getDate()).padStart(2, '0');
-    const timeStr = String(now.getHours()).padStart(2, '0') + ':' +
-                   String(now.getMinutes()).padStart(2, '0');
 
     let currentContent = textArea.value;
 
@@ -276,9 +274,9 @@ function addDateToTemplateBox(templateName) {
         if (hasExistingDate) {
             alert('既存の日付が検出されたため、日付の追加は行いません');
         } else {
-            const finalContent = `${dateStr} ${timeStr}\n\n${currentContent}`;
+            const finalContent = `${dateStr}\n\n${currentContent}`;
             textArea.value = finalContent;
-            alert(`${templateName}の先頭に日付・時刻を追加しました: ${dateStr} ${timeStr}`);
+            alert(`${templateName}の先頭に日付を追加しました: ${dateStr}`);
         }
     }
 }


### PR DESCRIPTION
## 修正内容

選択済みテンプレートボックスの「📅 日付付与」ボタンから時間付与を削除

### 問題
- `addDateToTemplateBox()`関数で時間も一緒に付与されていた
- メインの`addDateToMemo()`関数は修正済みだったが、テンプレートボックス用の関数が未修正

### Before
```
2025/09/29 14:30

テンプレート内容
```

### After  
```
2025/09/29

テンプレート内容
```

## 影響範囲
- `js/app.js`: addDateToTemplateBox()関数のtimeStr削除
- 既存の日付置換機能（yyyy/mm/dd、mm/dd）は影響なし

## テスト確認項目
- [ ] 選択済みテンプレートボックスの日付付与ボタンで時間が付与されないこと
- [ ] 日付のみが正しく付与されること
- [ ] 既存の日付置換機能が正常動作すること

🤖 Generated with [Claude Code](https://claude.ai/code)