### PR TITLE
fix: テンプレート表示窓の表示件数を6個に調整

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -175,7 +175,7 @@ textarea:focus {
 }
 
 .template-list {
-    max-height: 500px;
+    max-height: 600px;
     overflow-y: auto;
     border: 2px solid var(--border-purple);
     border-radius: 12px;


### PR DESCRIPTION
## 修正内容

テンプレート一覧表示窓の表示件数を5個から6個に拡張

### 問題
- 現在max-height: 500pxで5個のテンプレートが表示
- ユーザーから6個表示への要望

### 修正内容
- **Before**: max-height: 500px（5個表示）
- **After**: max-height: 600px（6個表示）

## 影響範囲
- `css/style.css`: .template-listのmax-height変更
- スクロール機能はそのまま維持

## 計算根拠
- 1テンプレートアイテム約100px（padding、border含む）
- 6個表示 = 600px
- 余裕を持った設定

## テスト確認項目
- [ ] テンプレート一覧で6個のテンプレートが表示されること
- [ ] スクロール機能が正常動作すること
- [ ] レイアウトが崩れないこと

🤖 Generated with [Claude Code](https://claude.ai/code)