### PR TITLE
fix: 新規メモの時刻削除と表示域全幅化

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -42,21 +42,22 @@
 body {
     font-family: 'Helvetica Neue', Arial, sans-serif;
     margin: 0;
-    padding: 20px;
+    padding: 0;
     background: linear-gradient(135deg, var(--very-light-purple) 0%, var(--purple-gray) 100%);
     color: var(--text-dark);
     min-height: 100vh;
 }
 
 .container {
-    max-width: 1200px;
-    margin: 0 auto;
+    width: 100%;
+    margin: 0;
     background: rgba(255, 255, 255, 0.95);
-    border-radius: 16px;
-    box-shadow: 0 8px 32px rgba(139, 92, 246, 0.15);
+    border-radius: 0;
+    box-shadow: none;
     backdrop-filter: blur(10px);
-    border: 1px solid var(--border-purple);
+    border: none;
     overflow: hidden;
+    min-height: 100vh;
 }
 
 .header {
@@ -449,15 +450,17 @@ input[type="text"]:focus {
 /* スマートフォン（シニア対応強化） */
 @media (max-width: 768px) {
     body {
-        padding: 8px;
+        padding: 0;
         font-size: var(--base-font-size);
         font-family: 'Hiragino Kaku Gothic ProN', 'Yu Gothic', 'Meiryo', 'Helvetica Neue', Arial, sans-serif;
         line-height: 1.6;
         color: var(--text-high-contrast);
     }
-    
+
     .container {
-        border-radius: 12px;
+        border-radius: 0;
+        width: 100%;
+        margin: 0;
     }
     
     .header h1 {

--- a/js/app.js
+++ b/js/app.js
@@ -467,13 +467,11 @@ function addDateToMemo() {
 
 function newMemo() {
     const now = new Date();
-    const dateStr = now.getFullYear() + '/' + 
-                   String(now.getMonth() + 1).padStart(2, '0') + '/' + 
+    const dateStr = now.getFullYear() + '/' +
+                   String(now.getMonth() + 1).padStart(2, '0') + '/' +
                    String(now.getDate()).padStart(2, '0');
-    const timeStr = String(now.getHours()).padStart(2, '0') + ':' + 
-                   String(now.getMinutes()).padStart(2, '0');
-    
-    document.getElementById('memoText').value = `${dateStr} ${timeStr}\n\n`;
+
+    document.getElementById('memoText').value = `${dateStr}\n\n`;
     document.getElementById('templateName').value = '';
     selectedTemplate = null;
     renderTemplateList();


### PR DESCRIPTION
## 修正内容

### 1. 新規メモ機能から時刻削除

**Before**: 新規メモボタンで `2025/09/29 14:30` （日付+時刻）
**After**: 新規メモボタンで `2025/09/29` （日付のみ）

#### 修正箇所
- `js/app.js`: newMemo()関数のtimeStr変数削除
- 時刻付与ロジック削除

### 2. 表示域の全幅化

**Before**: 左右に余白があり表示域が制限
**After**: 画面全幅を使用した表示域拡張

#### 修正詳細
- **body**: padding: 20px → 0
- **container**: 
  - max-width: 1200px → width: 100%
  - margin: 0 auto → margin: 0
  - border-radius: 16px → 0
  - box-shadow削除
- **レスポンシブ対応**: モバイルでも全幅表示

## 効果

### 表示域拡張
- **デスクトップ**: 3列レイアウトがより広い範囲で表示
- **作業効率**: より多くの内容を同時に表示可能
- **視認性**: テンプレート、メモ、選択済みテンプレートの領域拡大

### 一貫性向上
- 全ての日付付与機能で時刻なしに統一
- 画面領域の最大活用

## 影響範囲

- **JavaScript**: newMemo()関数の時刻削除
- **CSS**: レイアウト全幅化
- **既存機能**: 完全な後方互換性

## 確認項目

- [ ] 新規メモボタンで時刻が付与されないこと
- [ ] アプリが画面全幅で表示されること
- [ ] 3列レイアウトがより広く表示されること
- [ ] モバイルでも適切に表示されること

🤖 Generated with [Claude Code](https://claude.ai/code)