### PR TITLE
fix: 選択済みテンプレート表示域を大幅拡張

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -87,7 +87,7 @@ body {
 }
 
 .memo-area {
-    flex: 1;
+    width: 500px;
     padding: 20px;
     display: flex;
     flex-direction: column;
@@ -96,7 +96,8 @@ body {
 }
 
 .selected-templates-area {
-    width: 400px;
+    flex: 1;
+    min-width: 400px;
     background: rgba(255, 255, 255, 0.98);
     padding: 20px;
     display: flex;
@@ -273,8 +274,8 @@ textarea:focus {
 
 .selected-template-boxes {
     display: grid;
-    grid-template-columns: 1fr 1fr 1fr; /* 3列グリッド */
-    gap: 12px;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); /* 自動調整グリッド */
+    gap: 16px;
     flex: 1;
     overflow-y: auto;
     align-content: start;
@@ -284,32 +285,32 @@ textarea:focus {
 .template-box-container {
     border: 2px solid var(--border-purple);
     border-radius: 8px;
-    padding: 12px;
+    padding: 16px;
     background: rgba(255, 255, 255, 0.95);
     box-shadow: 0 2px 8px rgba(139, 92, 246, 0.1);
-    min-height: 200px;
+    min-height: 220px;
     display: flex;
     flex-direction: column;
 }
 
 .template-box-header {
-    margin: 0 0 8px 0;
+    margin: 0 0 10px 0;
     color: var(--primary-purple-dark);
-    font-size: 12px;
+    font-size: 14px;
     font-weight: 600;
     border-bottom: 1px solid var(--border-purple);
-    padding-bottom: 6px;
+    padding-bottom: 8px;
     flex-shrink: 0;
 }
 
 .template-box-textarea {
     width: 100%;
-    min-height: 80px;
-    padding: 8px;
+    min-height: 100px;
+    padding: 10px;
     border: 1px solid var(--border-purple);
     border-radius: 6px;
-    font-size: 12px;
-    line-height: 1.4;
+    font-size: 13px;
+    line-height: 1.5;
     font-family: 'Hiragino Kaku Gothic ProN', 'Yu Gothic', 'Meiryo', monospace;
     resize: vertical;
     background: rgba(255, 255, 255, 0.9);
@@ -336,10 +337,10 @@ textarea:focus {
 }
 
 .template-box-btn {
-    min-width: 50px;
-    min-height: 32px;
-    padding: 8px 6px;
-    font-size: 11px;
+    min-width: 60px;
+    min-height: 36px;
+    padding: 8px 10px;
+    font-size: 12px;
     font-weight: 600;
     border: none;
     border-radius: 4px;
@@ -484,6 +485,7 @@ input[type="text"]:focus {
     }
 
     .memo-area {
+        width: 100%; /* モバイルでは全幅に戻す */
         order: 2;
         padding: 16px;
         border-right: none;


### PR DESCRIPTION
## 修正内容

ユーザー要望に応じて、選択済みテンプレートの表示域を大幅に拡張し、バランスの良いレイアウトを実現しました。

### レイアウト変更

**Before**: 固定幅レイアウト
- テンプレート: 300px
- メモ本体: flex: 1（可変）
- 選択済みテンプレート: 400px（狭い）

**After**: 選択済みテンプレート優先レイアウト
- テンプレート: 300px（変更なし）
- メモ本体: 500px（固定幅）
- 選択済みテンプレート: flex: 1（残り全領域を使用）

### グリッド自動調整機能

**改善前**: 固定3列グリッド
```css
grid-template-columns: 1fr 1fr 1fr;
```

**改善後**: レスポンシブ自動調整グリッド
```css
grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
```

### 視認性向上

#### テンプレートボックス拡張
- **padding**: 12px → 16px
- **min-height**: 200px → 220px
- **gap**: 12px → 16px

#### フォント・サイズ調整
- **ヘッダー**: 12px → 14px
- **テキストエリア**: 80px → 100px、font-size: 13px
- **ボタン**: 32px → 36px、font-size: 12px

### レスポンシブ対応

- **デスクトップ**: 選択済みテンプレートが画面幅に応じて最大活用
- **モバイル**: memo-areaを100%幅に調整し、縦積みレイアウト維持

## 効果

### 表示域の大幅拡張
- 選択済みテンプレート域が画面幅の50%以上を使用可能
- 大画面では4-5列のテンプレート表示も実現
- より多くのテンプレートを同時に確認・操作可能

### バランス改善
- テンプレート選択（300px）は使いやすさを維持
- メモ編集（500px）は十分な編集領域を確保
- 選択済みテンプレート（残り全て）が最も重要な作業域として最大活用

### 視認性向上
- 個々のテンプレートボックスがより見やすく
- ボタンやテキストのサイズ向上で操作しやすく
- 余裕のある配置で整理された印象

## 技術的改善

- CSS Grid の auto-fit により画面サイズに最適化
- min-width 280px でテンプレートボックスの最小サイズ確保
- モバイルファーストのレスポンシブ設計維持

## 確認項目

- [ ] デスクトップで選択済みテンプレートが画面右側を最大活用すること
- [ ] グリッドが画面幅に応じて自動調整されること  
- [ ] テンプレートボックスが見やすいサイズで表示されること
- [ ] モバイルでも適切に縦積み表示されること
- [ ] 全ての既存機能が正常動作すること

🤖 Generated with [Claude Code](https://claude.ai/code)