### PR TITLE
fix: 選択済みテンプレートを横並び表示＆自動改行に変更

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -273,12 +273,14 @@ textarea:focus {
 /* 旧selected-templates-section削除済み（3列レイアウト対応） */
 
 .selected-template-boxes {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); /* 自動調整グリッド */
+    display: flex;
+    flex-direction: row; /* 横並びを明示 */
+    flex-wrap: wrap; /* 自動改行 */
     gap: 16px;
     flex: 1;
     overflow-y: auto;
-    align-content: start;
+    align-content: flex-start;
+    align-items: flex-start;
 }
 
 /* テンプレートボックス */
@@ -291,6 +293,9 @@ textarea:focus {
     min-height: 220px;
     display: flex;
     flex-direction: column;
+    flex: 0 0 auto; /* 固有サイズを維持 */
+    width: 280px; /* 適切な幅を設定 */
+    max-width: 320px; /* 最大幅制限 */
 }
 
 .template-box-header {
@@ -580,11 +585,13 @@ input[type="text"]:focus {
     }
 
     .selected-template-boxes {
-        grid-template-columns: 1fr; /* モバイルでは1列 */
+        flex-direction: column; /* モバイルでは縦並び */
         gap: 16px;
     }
 
     .template-box-container {
+        width: 100%; /* モバイルでは全幅 */
+        max-width: none;
         padding: 16px;
         margin-bottom: 0;
         min-height: auto;


### PR DESCRIPTION
## 修正内容

選択済みテンプレートが画面幅に余裕があるにも関わらず縦並びになる問題を解決し、横並び＆自動改行表示を実現しました。

### 問題

- CSS Grid の `repeat(auto-fit, minmax(280px, 1fr))` が期待通りに横並びにならない
- 画面サイズに余裕があっても選択済みテンプレートが縦に並ぶ
- テンプレート表示域を拡張したが、横並びの恩恵を受けられない

### 解決方法

**CSS GridからFlexboxに変更**

#### Before: CSS Grid
```css
.selected-template-boxes {
    display: grid;
    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
}
```

#### After: Flexbox
```css
.selected-template-boxes {
    display: flex;
    flex-direction: row; /* 横並びを明示 */
    flex-wrap: wrap; /* 自動改行 */
    align-items: flex-start;
}
```

### テンプレートボックス調整

- **固定サイズ**: width: 280px, max-width: 320px
- **フレックス**: flex: 0 0 auto で固有サイズ維持
- **レイアウト**: 横に並び、スペース不足時は下段に表示

### レスポンシブ対応

- **デスクトップ**: 横並び表示＆自動改行
- **モバイル**: flex-direction: column で縦並び
- **モバイル**: width: 100% で全幅活用

## 効果

### 横並び表示の実現
- 画面幅に応じて2列、3列、4列と自動調整
- 横に並びきらない場合は下段に自動改行
- 画面領域を最大限活用

### 視認性向上
- より多くのテンプレートを一覧表示
- 横並びで比較しやすいレイアウト
- 下段への自動改行でコンパクト表示

### レスポンシブ対応
- 大画面: 横並び表示で効率的
- 小画面: 縦並びで使いやすさ維持

## 技術的改善

- **確実性**: Flexboxによる明示的な横並び制御
- **柔軟性**: flex-wrap による自動改行
- **保守性**: シンプルで理解しやすいCSS

## 確認項目

- [ ] デスクトップで選択済みテンプレートが横並びで表示されること
- [ ] 画面幅不足時に下段に自動改行されること
- [ ] モバイルで縦並び表示されること
- [ ] テンプレートボックスのサイズが適切であること

🤖 Generated with [Claude Code](https://claude.ai/code)