### PR TITLE
fix: 選択済みテンプレートの横並び表示を強制修正

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -634,6 +634,14 @@ input[type="text"]:focus {
     }
 }
 
+/* デスクトップ・タブレット: 横並び強制 */
+@media (min-width: 769px) {
+    .selected-template-boxes {
+        flex-direction: row !important; /* デスクトップでは強制的に横並び */
+        flex-wrap: wrap !important; /* 自動改行 */
+    }
+}
+
 /* タブレット */
 @media (min-width: 769px) and (max-width: 1024px) {
     .main-content {


### PR DESCRIPTION
## Summary
- デスクトップ・タブレット環境で選択済みテンプレートが縦並びになる問題を修正
- 768px以下のモバイル用メディアクエリがデスクトップでも適用される問題を解決

## 修正内容
### Before
- 769px以上の画面でも選択済みテンプレートが縦並び表示
- モバイル用の `flex-direction: column` 設定がデスクトップにも影響

### After  
- 769px以上では強制的に横並び表示（`flex-direction: row !important`）
- 自動改行機能も維持（`flex-wrap: wrap !important`）

## 技術的変更
```css
/* デスクトップ・タブレット: 横並び強制 */
@media (min-width: 769px) {
    .selected-template-boxes {
        flex-direction: row !important; /* デスクトップでは強制的に横並び */
        flex-wrap: wrap !important; /* 自動改行 */
    }
}
```

## Test plan
- [ ] デスクトップ（1200px以上）での横並び表示確認
- [ ] タブレット（769px-1024px）での横並び表示確認  
- [ ] モバイル（768px以下）での縦並び表示維持確認
- [ ] テンプレート選択時の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)