### PR TITLE
fix: 選択済みテンプレート横並び表示の強化修正

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -636,9 +636,18 @@ input[type="text"]:focus {
 
 /* デスクトップ・タブレット: 横並び強制 */
 @media (min-width: 769px) {
-    .selected-template-boxes {
+    .selected-templates-area .selected-template-boxes,
+    #selectedTemplateBoxes,
+    div.selected-template-boxes {
         flex-direction: row !important; /* デスクトップでは強制的に横並び */
         flex-wrap: wrap !important; /* 自動改行 */
+        display: flex !important; /* flex確保 */
+    }
+
+    /* さらに強力な指定 */
+    .main-content .selected-templates-area .selected-template-boxes {
+        flex-direction: row !important;
+        flex-wrap: wrap !important;
     }
 }
 


### PR DESCRIPTION
## Summary
GitHub Pagesで確認したところ、前回の修正でも選択済みテンプレートが縦並びのままでした。
より強力なCSS Specificityを使用して、確実に横並び表示を実現します。

## 問題の分析
- 前回の `!important` による修正でも縦並びのまま
- CSS優先順位（Specificity）がまだ不十分
- より詳細なセレクタと組み合わせが必要

## 強化された修正内容
### 複数セレクタによる確実な指定
```css
@media (min-width: 769px) {
    .selected-templates-area .selected-template-boxes,
    #selectedTemplateBoxes,
    div.selected-template-boxes {
        flex-direction: row !important;
        flex-wrap: wrap !important;
        display: flex !important;
    }

    /* さらに強力な指定 */
    .main-content .selected-templates-area .selected-template-boxes {
        flex-direction: row !important;
        flex-wrap: wrap !important;
    }
}
```

## CSS Specificity強化ポイント
1. **クラス + ID併用**: `.selected-template-boxes` + `#selectedTemplateBoxes`
2. **親要素との組み合わせ**: `.selected-templates-area .selected-template-boxes`
3. **階層指定**: `.main-content .selected-templates-area .selected-template-boxes`
4. **要素タイプ指定**: `div.selected-template-boxes`

## Test plan
- [ ] デスクトップ（1200px以上）での横並び表示確認
- [ ] タブレット（769px-1024px）での横並び表示確認
- [ ] モバイル（768px以下）での縦並び表示維持確認
- [ ] GitHub Pages での実際の表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)