### PR TITLE
feat: 選択済みテンプレート可変グリッドレスポンシブ対応

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -273,14 +273,12 @@ textarea:focus {
 /* 旧selected-templates-section削除済み（3列レイアウト対応） */
 
 .selected-template-boxes {
-    display: flex;
-    flex-direction: row; /* 横並びを明示 */
-    flex-wrap: wrap; /* 自動改行 */
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); /* 可変グリッド */
     gap: 16px;
     flex: 1;
     overflow-y: auto;
-    align-content: flex-start;
-    align-items: flex-start;
+    align-content: start;
 }
 
 /* テンプレートボックス */
@@ -586,8 +584,9 @@ input[type="text"]:focus {
     }
 
     .selected-template-boxes {
-        flex-direction: column; /* モバイルでは縦並び */
-        gap: 16px;
+        display: grid !important;
+        grid-template-columns: 1fr !important; /* モバイルでは1列 */
+        gap: 16px !important;
     }
 
     .template-box-container {
@@ -635,44 +634,42 @@ input[type="text"]:focus {
     }
 }
 
-/* デスクトップ・タブレット: 横並び強制とボックス幅修正 */
+/* レスポンシブグリッドレイアウト: タブレット・デスクトップ対応 */
 @media (min-width: 769px) {
+    /* グリッドレイアウトの継続使用 */
     .selected-templates-area .selected-template-boxes,
     #selectedTemplateBoxes,
     div.selected-template-boxes {
-        flex-direction: row !important; /* デスクトップでは強制的に横並び */
-        flex-wrap: wrap !important; /* 自動改行 */
-        display: flex !important; /* flex確保 */
+        display: grid !important;
     }
 
-    /* さらに強力な指定 */
-    .main-content .selected-templates-area .selected-template-boxes {
-        flex-direction: row !important;
-        flex-wrap: wrap !important;
+    /* タブレット: 最大3列表示 */
+    .selected-template-boxes {
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)) !important;
+        gap: 12px !important;
     }
 
-    /* 最適化: テンプレートボックス幅とボタンサイズ調整 */
+    /* テンプレートボックス: 可変幅対応 */
     .template-box-container {
-        width: 350px !important; /* 4ボタン余裕幅に拡大 */
-        max-width: 350px !important; /* 固定幅 */
-        flex: 0 0 auto !important; /* サイズ維持 */
+        width: auto !important; /* グリッド自動調整 */
+        min-width: 180px !important; /* 最小幅確保 */
+        max-width: none !important; /* 最大幅制限解除 */
     }
 
-    /* ボタンサイズ最適化: アイコン中心の簡潔表示 */
+    /* ボタンサイズ最適化 */
     .template-box-btn {
-        min-width: 36px !important; /* 少し余裕を持たせる */
-        min-height: 36px !important;
-        padding: 8px !important;
-        font-size: 14px !important;
+        min-width: 28px !important;
+        min-height: 32px !important;
+        padding: 6px 3px !important;
+        font-size: 12px !important;
         font-weight: 500 !important;
-        border-radius: 6px !important;
-        flex: 1 !important; /* ボタン幅を均等分割 */
+        border-radius: 4px !important;
+        flex: 1 !important;
     }
 
-    /* ボタンコンテナもデスクトップで最適化 */
     .template-box-buttons {
-        flex-wrap: nowrap !important; /* 絶対に折り返さない */
-        gap: 6px !important; /* 適切な間隔 */
+        flex-wrap: nowrap !important;
+        gap: 3px !important;
     }
 }
 
@@ -703,11 +700,27 @@ input[type="text"]:focus {
         max-width: 1200px;
         margin: 0 auto;
     }
-    
+
     .sidebar {
         width: 350px;
     }
-    
+
+    /* デスクトップ: より多くの列表示可能 */
+    .selected-template-boxes {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)) !important;
+        gap: 16px !important;
+    }
+
+    .template-box-container {
+        min-width: 220px !important;
+    }
+
+    .template-box-btn {
+        min-width: 32px !important;
+        padding: 8px 4px !important;
+        gap: 4px !important;
+    }
+
     /* フォーカス表示を大きめに */
     .btn:focus, input:focus, textarea:focus {
         outline-width: var(--focus-outline-width);


### PR DESCRIPTION
## Summary
各環境で約3つ並べて表示できる完全レスポンシブ対応を実装しました。CSS Gridベースの可変レイアウトで画面幅を最大限活用します。

## 実装内容

### 1. CSS Grid レスポンシブレイアウト
```css
/* 基本グリッド */
.selected-template-boxes {
    display: grid;
    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
    gap: 16px;
}
```

### 2. 画面サイズ別最適化

#### モバイル (768px以下)
```css
.selected-template-boxes {
    grid-template-columns: 1fr !important; /* 1列表示 */
    gap: 16px !important;
}
```

#### タブレット (769px-1024px)  
```css
.selected-template-boxes {
    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)) !important;
    gap: 12px !important;
}
```
- **2-3列表示**: 400px幅で約2個、600px幅で3個表示

#### デスクトップ (1025px+)
```css  
.selected-template-boxes {
    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)) !important;
    gap: 16px !important;  
}
```
- **3-4列表示**: 選択済みエリア500px+幅で3個以上表示

### 3. テンプレートボックス可変幅対応
```css
.template-box-container {
    width: auto !important; /* グリッド自動調整 */
    min-width: 180px-220px !important; /* 画面サイズ別 */
    max-width: none !important; /* 制限解除 */
}
```

### 4. ボタンサイズ最適化
各画面サイズでボタンサイズを調整：
- **タブレット**: 28px × 32px, padding: 6px 3px
- **デスクトップ**: 32px × 32px, padding: 8px 4px
- **gap**: 3px-4px で最適間隔

## 技術的メリット

### 1. 自動レスポンシブ対応  
- `repeat(auto-fit, minmax())`: 画面幅に応じて最適列数を自動計算
- `1fr`: 利用可能幅を均等分割で最大活用

### 2. 確実な表示品質
- **min-width保証**: 4ボタンが確実に収まる最小幅
- **gap調整**: 適切な間隔で視認性確保

### 3. 保守性向上
- CSS Gridの明確な構造
- 画面サイズ別の明示的な設定

## 表示例

### タブレット横向き (1024px)
```
[Template1] [Template2] [Template3]
[Template4] [Template5] ...
```

### デスクトップ (1200px)  
```
[Template1] [Template2] [Template3] [Template4]
[Template5] [Template6] ...
```

## Test plan
- [ ] モバイル縦: 1列表示確認
- [ ] タブレット縦: 2列表示確認  
- [ ] タブレット横: 3列表示確認
- [ ] デスクトップ: 3-4列表示確認
- [ ] ブラウザ幅変更時の動的調整確認
- [ ] 4ボタン横並び表示確認

**GitHub Pages**: https://purplehoge.github.io/memo-app/

🤖 Generated with [Claude Code](https://claude.ai/code)