### PR TITLE
fix: フルHD環境での選択済みテンプレート複数列表示対応

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -274,8 +274,8 @@ textarea:focus {
 
 .selected-template-boxes {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); /* 可変グリッド */
-    gap: 16px;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); /* 現実的な最小幅 */
+    gap: 12px;
     flex: 1;
     overflow-y: auto;
     align-content: start;
@@ -645,14 +645,14 @@ input[type="text"]:focus {
 
     /* タブレット: 最大3列表示 */
     .selected-template-boxes {
-        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)) !important;
-        gap: 12px !important;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)) !important;
+        gap: 10px !important;
     }
 
     /* テンプレートボックス: 可変幅対応 */
     .template-box-container {
         width: auto !important; /* グリッド自動調整 */
-        min-width: 180px !important; /* 最小幅確保 */
+        min-width: 140px !important; /* タブレット用最小幅 */
         max-width: none !important; /* 最大幅制限解除 */
     }
 
@@ -705,20 +705,22 @@ input[type="text"]:focus {
         width: 350px;
     }
 
-    /* デスクトップ: より多くの列表示可能 */
+    /* デスクトップ: 310px幅で3列表示対応 */
     .selected-template-boxes {
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)) !important;
-        gap: 16px !important;
+        grid-template-columns: repeat(auto-fit, minmax(90px, 1fr)) !important;
+        gap: 8px !important;
     }
 
     .template-box-container {
-        min-width: 220px !important;
+        min-width: 90px !important;
     }
 
     .template-box-btn {
-        min-width: 32px !important;
-        padding: 8px 4px !important;
-        gap: 4px !important;
+        min-width: 20px !important; /* 狭い幅でも4ボタン収納 */
+        max-width: 30px !important;
+        padding: 4px 2px !important;
+        font-size: 11px !important;
+        gap: 2px !important;
     }
 
     /* フォーカス表示を大きめに */


### PR DESCRIPTION
## Summary
フルHD環境で選択済みテンプレートが1列表示される問題を修正しました。実際のコンテナ幅に対してminmax値を現実的な値に調整し、3列表示を実現します。

## 問題分析

### フルHD環境での実際の幅計算
```
フルHD (1920px)
├── 全体: max-width 1200px (中央配置)
├── サイドバー: 350px
├── メモエリア: 500px  
├── Gap: 40px (20px × 2)
└── 選択済みエリア: 310px (1200-350-500-40)
```

### 問題の根本原因
```css
/* Before: 実際の幅に対してminmax値が大きすぎる */
grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
/* 220px × 2列 = 440px > 310px → 1列のみ表示 */

/* After: 現実的なminmax値 */  
grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
/* 90px × 3列 = 270px < 310px → 3列表示可能 */
```

## 修正内容

### 1. CSS Grid minmax値の現実的調整

#### 基本設定 (全画面サイズ)
```css
.selected-template-boxes {
-   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-   gap: 16px;
+   gap: 12px;
}
```

#### タブレット (769px-1024px)
```css  
.selected-template-boxes {
-   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)) !important;
+   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)) !important;
-   gap: 12px !important;
+   gap: 10px !important;
}
```

#### デスクトップ (1025px+)
```css
.selected-template-boxes {
-   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)) !important;
+   grid-template-columns: repeat(auto-fit, minmax(90px, 1fr)) !important;
-   gap: 16px !important;
+   gap: 8px !important;
}
```

### 2. 狭い幅に対応したボタンサイズ最適化
```css
.template-box-btn {
+   min-width: 20px !important; /* 狭い幅でも4ボタン収納 */
+   max-width: 30px !important;
+   padding: 4px 2px !important;
+   font-size: 11px !important;
+   gap: 2px !important;
}
```

## 技術的解決効果

### 1. 各環境での表示列数
- **フルHD**: 310px幅で3列表示  
- **タブレット**: 2-3列表示
- **モバイル**: 1列表示維持

### 2. 画面幅の最大活用
- CSS Grid `auto-fit` で利用可能幅を自動分割
- `1fr` で余白を均等配分
- gap調整で視認性確保

### 3. ボタン視認性確保  
- 最小幅20pxでも4ボタン横並び可能
- アイコンベース表示で機能識別性維持
- ツールチップで詳細説明

## 表示例

### フルHD (1920px) - 選択済みエリア310px
```
[📝 Template1] [📝 Template2] [📝 Template3]
[📝 Template4] [📝 Template5] ...
```

### タブレット (1024px) - 選択済みエリア約400px
```  
[📝 Template1] [📝 Template2] [📝 Template3]
[📝 Template4] ...
```

## Test plan
- [ ] フルHD(1920px): 3列表示確認
- [ ] タブレット横(1024px): 3列表示確認
- [ ] タブレット縦(768px): 2列表示確認  
- [ ] モバイル(375px): 1列表示確認
- [ ] 各ボックス内4ボタン横並び確認
- [ ] ブラウザ幅変更時の動的調整確認

**GitHub Pages**: https://purplehoge.github.io/memo-app/

🤖 Generated with [Claude Code](https://claude.ai/code)