### PR TITLE
左詰めレイアウトで選択済みテンプレートエリア拡大

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -694,11 +694,12 @@ input[type="text"]:focus {
     }
 }
 
-/* 大画面でのアクセシビリティ配慮 */
+/* 大画面でのアクセシビリティ配慮 - 左詰めレイアウト */
 @media (min-width: 1025px) {
     .main-content {
-        max-width: 1200px;
-        margin: 0 auto;
+        max-width: none;         /* 幅制限解除 */
+        margin: 0 0 0 20px;      /* 左余白のみ */
+        padding-right: 20px;     /* 右余白 */
     }
 
     .sidebar {

--- a/docs/03_詳細設計.md
+++ b/docs/03_詳細設計.md
@@ -481,14 +481,21 @@ const CONFIG = {
     }
 }
 
-/* デスクトップ */
+/* デスクトップ - 左詰めレイアウト */
 @media (min-width: 1025px) {
-    .main-content { 
-        flex-direction: row; 
-        max-width: 1200px;
-        margin: 0 auto;
+    .main-content {
+        flex-direction: row;
+        max-width: none;         /* 幅制限解除 */
+        margin: 0 0 0 20px;      /* 左余白のみ */
+        padding-right: 20px;     /* 右余白 */
     }
     .sidebar { width: 350px; }
+
+    /* 選択済みテンプレートエリアの拡大効果 */
+    .selected-templates-area {
+        /* flex: 1により自動的に最大幅まで拡大 */
+        /* フルHD環境で約1000px以上の幅を確保可能 */
+    }
 }
 ```
 


### PR DESCRIPTION
## Summary
フルHD環境で選択済みテンプレートエリアの表示幅を大幅拡大する左詰めレイアウトに変更

## 修正内容

### Before
- 中央寄せレイアウト: `max-width: 1200px; margin: 0 auto;`
- 選択済みテンプレートエリア幅: 約350px（制限あり）
- フルHD環境でも最大1200px幅まで

### After  
- 左詰めレイアウト: `max-width: none; margin: 0 0 0 20px; padding-right: 20px;`
- 選択済みテンプレートエリア幅: 約1000px以上（フルHD環境）
- 画面全幅から左右余白40pxを除いた最大幅を利用

## 期待される効果
- フルHD環境で5-6個のテンプレートボックスを横並び表示可能
- 既存のCSSグリッドレイアウトによる自動調整でより効率的な配置
- 大画面でのユーザビリティ向上

## 影響範囲
- **変更対象**: デスクトップ（1025px以上）のみ
- **既存機能**: 影響なし（表示領域拡大のみ）  
- **レスポンシブ**: モバイル・タブレット表示は変更なし
- **アクセシビリティ**: 継続維持

## Test plan
- [ ] フルHD環境（1920px）での表示幅拡大確認
- [ ] 他の画面サイズでのレイアウト継続確認
- [ ] 選択済みテンプレートボックスの横並び表示向上確認
- [ ] 既存機能（チェック・編集・削除）の正常動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)