### PR TITLE
選択済みテンプレートボックスを3列表示に最適化

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -706,22 +706,24 @@ input[type="text"]:focus {
         width: 350px;
     }
 
-    /* デスクトップ: 310px幅で3列表示対応 */
+    /* デスクトップ: 3列表示に最適化 */
     .selected-template-boxes {
-        grid-template-columns: repeat(auto-fit, minmax(90px, 1fr)) !important;
-        gap: 8px !important;
+        grid-template-columns: repeat(3, 1fr) !important; /* 固定3列 */
+        gap: 16px !important;
     }
 
     .template-box-container {
-        min-width: 90px !important;
+        min-width: 280px !important; /* 適切な表示幅 */
+        max-width: 350px !important; /* 最大幅制限 */
+        width: auto !important;
     }
 
     .template-box-btn {
-        min-width: 20px !important; /* 狭い幅でも4ボタン収納 */
-        max-width: 30px !important;
-        padding: 4px 2px !important;
-        font-size: 11px !important;
-        gap: 2px !important;
+        min-width: 60px !important; /* 読みやすいボタンサイズ */
+        min-height: 36px !important;
+        padding: 8px 12px !important;
+        font-size: 12px !important;
+        gap: 4px !important;
     }
 
     /* フォーカス表示を大きめに */


### PR DESCRIPTION
## Summary
左詰めレイアウトでの極端なテンプレートボックス拡大を修正し、適切な3列表示を実現

## 修正内容

### Before（問題）
- `grid-template-columns: repeat(auto-fit, minmax(90px, 1fr))`
- 左詰めレイアウトで利用可能幅が1000px以上に拡大
- 最小90pxから過度に横伸びして極端に大きなボックス表示
- ボタンサイズ20-30pxで視認性・操作性不良

### After（解決）
- `grid-template-columns: repeat(3, 1fr)` - 固定3列レイアウト
- テンプレートボックス: 280px-350px幅で適切表示
- ボタンサイズ: 60px×36px読みやすく操作しやすいサイズ
- gap: 16px適切な間隔

## 期待される効果
- **視認性向上**: 適切なサイズでテンプレート内容が読みやすい
- **操作性向上**: ボタンが押しやすいサイズに最適化
- **レイアウト安定**: 3列固定で次の段への自然な流れ
- **拡張性**: 6個、9個選択時の整然とした表示

## 影響範囲
- **変更対象**: デスクトップ（1025px以上）のみ
- **既存機能**: 影響なし（表示サイズ最適化のみ）
- **レスポンシブ**: モバイル・タブレットは変更なし
- **左詰めレイアウト**: 継続使用、サイズのみ適正化

## Test plan
- [ ] フルHD環境で3列×複数段の適切な表示確認
- [ ] テンプレートボックスサイズの適切性確認（280-350px）
- [ ] ボタンサイズ・操作性の向上確認
- [ ] 他の画面サイズでの既存レイアウト維持確認

🤖 Generated with [Claude Code](https://claude.ai/code)