### PR TITLE
本文が空でも日付付与を可能にする

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -427,12 +427,14 @@ function addDateToMemo() {
     const dateStr = now.getFullYear() + '/' +
                    String(now.getMonth() + 1).padStart(2, '0') + '/' +
                    String(now.getDate()).padStart(2, '0');
-    
+
     const memoTextArea = document.getElementById('memoText');
     let currentContent = memoTextArea.value;
-    
+
+    // 本文が空の場合は日付のみを設定
     if (!currentContent.trim()) {
-        alert('メモの内容がありません');
+        memoTextArea.value = dateStr + '\n\n';
+        alert('📅 日付を追加しました: ' + dateStr);
         return;
     }
     


### PR DESCRIPTION
## Summary
メモ内容が空でも日付付与ボタンを使用可能にしてユーザビリティ向上

## 修正内容

### Before（問題）
- 本文が空の場合: `alert('メモの内容がありません')` でエラー終了
- 日付のみでメモを開始することができない
- 新規メモ作成時に日付付与できない

### After（解決）
- 本文が空の場合: 日付のみを追加してメモ開始をサポート
- `'📅 日付を追加しました: YYYY/MM/DD'` でフィードバック
- 日付の後に2行改行を追加して入力しやすい状態に

### 具体的変更
```javascript
// Before
if (!currentContent.trim()) {
    alert('メモの内容がありません');
    return;
}

// After
if (!currentContent.trim()) {
    memoTextArea.value = dateStr + '\n\n';
    alert('📅 日付を追加しました: ' + dateStr);
    return;
}
```

## ユースケース改善

### 新規メモ作成フロー
1. メモエリアが空の状態で「📅 日付付与」ボタンクリック
2. 自動的に今日の日付（YYYY/MM/DD形式）が挿入
3. 日付の下に2行空行が追加され、すぐに入力開始可能

### 既存機能との連携
- 日付付与後に新規メモ作成でも適切に動作
- 既存の置換機能（mm/dd, yyyy/mm/dd）は変更なし
- プレースホルダ置換と空文書への日付追加が両立

## 影響範囲
- **変更対象**: `addDateToMemo()`関数の空チェック部分のみ
- **既存機能**: 置換機能・その他の動作は一切変更なし
- **ユーザビリティ**: 日付ベースのメモ作成フローが向上
- **後方互換性**: 100%維持

## Test plan
- [ ] 空のメモエリアでの日付付与動作確認
- [ ] 日付挿入後の改行・カーソル位置確認
- [ ] 既存の置換機能（mm/dd, yyyy/mm/dd）の正常動作確認
- [ ] 他のボタン機能への影響なし確認

🤖 Generated with [Claude Code](https://claude.ai/code)