### PR TITLE
テンプレート列に一括チェック・解除機能を追加

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -424,6 +424,19 @@ textarea:focus {
     margin-top: 15px;
 }
 
+.bulk-selection-controls {
+    display: flex;
+    gap: 5px;
+    margin-top: 10px;
+    margin-bottom: 15px;
+}
+
+.bulk-selection-controls .btn {
+    font-size: 12px;
+    padding: 6px 12px;
+    flex: 1;
+}
+
 input[type="text"] {
     width: 100%;
     padding: 10px 14px;

--- a/index.html
+++ b/index.html
@@ -24,6 +24,11 @@
                         <button class="btn btn-danger" onclick="deleteTemplate()">削除</button>
                     </div>
 
+                    <div class="bulk-selection-controls">
+                        <button class="btn btn-secondary" onclick="selectAllTemplates()">☑️ 一括チェック</button>
+                        <button class="btn btn-secondary" onclick="clearAllTemplates()">☐ チェック一括解除</button>
+                    </div>
+
                     <div class="template-list" id="templateList">
                     </div>
                 </div>

--- a/js/app.js
+++ b/js/app.js
@@ -162,6 +162,52 @@ function toggleTemplateSelection(templateName) {
 }
 
 /**
+ * 全テンプレートを一括チェック
+ */
+function selectAllTemplates() {
+    const templateNames = Object.keys(templates);
+
+    if (templateNames.length === 0) {
+        alert('チェックするテンプレートがありません');
+        return;
+    }
+
+    // 全テンプレートをselectedTemplatesに追加
+    templateNames.forEach(name => {
+        selectedTemplates.add(name);
+    });
+
+    // 状態保存と表示更新
+    saveSelectedTemplates();
+    renderTemplateList();
+    renderSelectedTemplateBoxes();
+
+    alert(`☑️ ${templateNames.length}個のテンプレートを一括チェックしました`);
+}
+
+/**
+ * 全テンプレートのチェックを一括解除
+ */
+function clearAllTemplates() {
+    if (selectedTemplates.size === 0) {
+        alert('チェックを解除するテンプレートがありません');
+        return;
+    }
+
+    const previousCount = selectedTemplates.size;
+
+    // 全選択状態をクリア
+    selectedTemplates.clear();
+
+    // 状態保存と表示更新
+    saveSelectedTemplates();
+    renderTemplateList();
+    renderSelectedTemplateBoxes();
+
+    alert(`☐ ${previousCount}個のテンプレートのチェックを一括解除しました`);
+}
+
+/**
  * 選択済みテンプレートのテキストボックス群を描画する
  */
 function renderSelectedTemplateBoxes() {


### PR DESCRIPTION
## Summary
複数テンプレート選択時のユーザビリティ向上のため、一括チェック・解除機能を追加

## 新機能

### 一括チェック機能
- ボタン: `☑️ 一括チェック`
- 動作: 全テンプレートを一度にチェック状態に変更
- フィードバック: `☑️ N個のテンプレートを一括チェックしました`

### チェック一括解除機能
- ボタン: `☐ チェック一括解除`
- 動作: 全テンプレートのチェック状態を一度に解除
- フィードバック: `☐ N個のテンプレートのチェックを一括解除しました`

## 実装詳細

### HTML構造
```html
<div class=\"bulk-selection-controls\">
    <button class=\"btn btn-secondary\" onclick=\"selectAllTemplates()\">☑️ 一括チェック</button>
    <button class=\"btn btn-secondary\" onclick=\"clearAllTemplates()\">☐ チェック一括解除</button>
</div>
```

### JavaScript関数
```javascript
// 全テンプレートを一括チェック
function selectAllTemplates() {
    const templateNames = Object.keys(templates);
    templateNames.forEach(name => selectedTemplates.add(name));
    // 状態保存・UI更新・フィードバック
}

// 全テンプレートのチェックを一括解除
function clearAllTemplates() {
    selectedTemplates.clear();
    // 状態保存・UI更新・フィードバック
}
```

### CSS スタイル
```css
.bulk-selection-controls {
    display: flex;
    gap: 5px;
    margin-top: 10px;
    margin-bottom: 15px;
}

.bulk-selection-controls .btn {
    font-size: 12px;
    padding: 6px 12px;
    flex: 1; /* 2つのボタンが均等配置 */
}
```

## ユーザビリティ向上

### 使用場面
1. **大量テンプレート管理**: 10個以上のテンプレートを扱う場合
2. **一括操作**: 全テンプレートを選択してバッチ処理
3. **選択リセット**: 選択状態を一度にクリアして再選択

### エラーハンドリング
- **一括チェック時**: テンプレートが0個の場合の適切なメッセージ
- **一括解除時**: 選択済みが0個の場合の適切なメッセージ

### 既存機能との連携
- **個別チェック**: 従来の個別チェック機能と完全互換
- **選択済みエリア**: 一括操作後も選択済みテンプレートエリアと連動
- **永続化**: 選択状態はローカルストレージに自動保存

## 影響範囲
- **新規追加**: 一括操作機能のみ追加
- **既存機能**: 一切の変更・影響なし
- **データ構造**: 既存のselectedTemplates(Set)をそのまま活用
- **UI配置**: テンプレート保存・削除ボタンの下に配置

## Test plan
- [ ] テンプレート0個時の一括チェック動作確認
- [ ] テンプレート複数個時の一括チェック動作確認
- [ ] 選択済み0個時の一括解除動作確認
- [ ] 選択済み複数個時の一括解除動作確認
- [ ] 一括操作後の選択済みエリア連動確認
- [ ] 一括操作後の永続化確認
- [ ] 個別チェックとの組み合わせ動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)