### PR TITLE
一括操作ボタンを保存・削除ボタンと同一行に配置

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -422,19 +422,14 @@ textarea:focus {
     display: flex;
     gap: 5px;
     margin-top: 15px;
+    flex-wrap: wrap;
 }
 
-.bulk-selection-controls {
-    display: flex;
-    gap: 5px;
-    margin-top: 10px;
-    margin-bottom: 15px;
-}
-
-.bulk-selection-controls .btn {
-    font-size: 12px;
-    padding: 6px 12px;
-    flex: 1;
+.template-controls .btn-small {
+    font-size: 11px;
+    padding: 6px 8px;
+    min-width: auto;
+    flex: none;
 }
 
 input[type="text"] {

--- a/index.html
+++ b/index.html
@@ -22,11 +22,8 @@
                     <div class="template-controls">
                         <button class="btn btn-success" onclick="saveTemplate()">保存</button>
                         <button class="btn btn-danger" onclick="deleteTemplate()">削除</button>
-                    </div>
-
-                    <div class="bulk-selection-controls">
-                        <button class="btn btn-secondary" onclick="selectAllTemplates()">☑️ 一括チェック</button>
-                        <button class="btn btn-secondary" onclick="clearAllTemplates()">☐ チェック一括解除</button>
+                        <button class="btn btn-secondary btn-small" onclick="selectAllTemplates()">☑️ 一括チェック</button>
+                        <button class="btn btn-secondary btn-small" onclick="clearAllTemplates()">☐ 一括解除</button>
                     </div>
 
                     <div class="template-list" id="templateList">


### PR DESCRIPTION
## Summary
UI配置の最適化とスペース効率向上のため、一括操作ボタンを保存・削除ボタンと同一行に配置

## 修正内容

### Before（問題）
- **2行レイアウト**: 保存・削除ボタンと一括操作ボタンが別々の行
- **スペース浪費**: サイドバーの縦スペースを過度に消費
- **視覚的分離**: 関連機能が物理的に離れている

```html
<div class="template-controls">
    <button>保存</button>
    <button>削除</button>
</div>
<div class="bulk-selection-controls">
    <button>☑️ 一括チェック</button>
    <button>☐ チェック一括解除</button>
</div>
```

### After（解決）
- **1行レイアウト**: 4つのボタンを同一行に統合
- **サイズ最適化**: 一括操作ボタンを小サイズで配置
- **視覚的統合**: 関連機能の論理的グループ化

```html
<div class="template-controls">
    <button>保存</button>
    <button>削除</button>
    <button class="btn-small">☑️ 一括チェック</button>
    <button class="btn-small">☐ 一括解除</button>
</div>
```

## デザイン調整

### ボタンサイズ階層
1. **メイン操作**（保存・削除）: 標準サイズ維持
2. **補助操作**（一括選択）: 小サイズで省スペース化

### CSS調整
```css
.template-controls {
    display: flex;
    gap: 5px;
    margin-top: 15px;
    flex-wrap: wrap; /* 画面幅に応じて自動折り返し */
}

.template-controls .btn-small {
    font-size: 11px;
    padding: 6px 8px;
    min-width: auto;
    flex: none;
}
```

### テキスト短縮
- `☑️ 一括チェック` → そのまま
- `☐ チェック一括解除` → `☐ 一括解除`（文字数削減）

## ユーザビリティ向上

### スペース効率
- **縦スペース削減**: 1行削減でテンプレート一覧表示領域拡大
- **横配置**: 関連操作の論理的配置

### 視覚的改善
- **機能グループ化**: テンプレート操作が一箇所に集約
- **優先度明確化**: メイン操作（大）と補助操作（小）の視覚的差別化

### レスポンシブ対応
- **flex-wrap**: 画面幅が狭い場合は自動で2行に折り返し
- **既存デザイン維持**: モバイル表示への影響なし

## 影響範囲
- **変更対象**: テンプレート操作ボタンの配置のみ
- **機能面**: 一切の変更なし（レイアウトのみ）
- **既存CSS**: 不要なbulk-selection-controlsを削除

## Test plan
- [ ] デスクトップでの4ボタン横並び表示確認
- [ ] 各ボタンのサイズ・フォントの適切性確認
- [ ] 一括操作機能の正常動作確認
- [ ] レスポンシブ表示での折り返し動作確認
- [ ] モバイル・タブレット表示での影響なし確認

🤖 Generated with [Claude Code](https://claude.ai/code)