### PR TITLE
fix: 一括ボタンを保存・削除と同じサイズに統一

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -429,16 +429,8 @@ textarea:focus {
 .template-controls .btn {
     margin: 2px 0; /* 縦のmarginを削減 */
     line-height: 1.2; /* line-heightを調整 */
-}
-
-.template-controls .btn-small {
-    font-size: 10px;
-    padding: 4px 6px;
-    min-width: auto;
-    flex: none;
-    margin: 2px 0;
-    line-height: 1.1;
-    border-radius: 4px; /* 小さめの角丸 */
+    flex: 1; /* 4つのボタンを均等配置 */
+    min-width: 0; /* flex縮小を許可 */
 }
 
 input[type="text"] {

--- a/index.html
+++ b/index.html
@@ -22,8 +22,8 @@
                     <div class="template-controls">
                         <button class="btn btn-success" onclick="saveTemplate()">保存</button>
                         <button class="btn btn-danger" onclick="deleteTemplate()">削除</button>
-                        <button class="btn btn-secondary btn-small" onclick="selectAllTemplates()">☑️ 一括チェック</button>
-                        <button class="btn btn-secondary btn-small" onclick="clearAllTemplates()">☐ 一括解除</button>
+                        <button class="btn btn-secondary" onclick="selectAllTemplates()">一括☑</button>
+                        <button class="btn btn-secondary" onclick="clearAllTemplates()">☑解除</button>
                     </div>
 
                     <div class="template-list" id="templateList">


### PR DESCRIPTION
## Summary
- 一括チェック・解除ボタンのテキストを「一括☑」「☑解除」に簡潔化
- 保存・削除ボタンと同じサイズに統一
- flex: 1 による4ボタンの均等配置

## Test plan
- [x] ボタンサイズの統一確認
- [x] レスポンシブ表示の確認
- [x] 既存機能の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)