### PR TITLE
fix: チェック系ボタンのレイアウト最適化

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -430,7 +430,8 @@ textarea:focus {
     margin: 2px 0; /* 縦のmarginを削減 */
     line-height: 1.2; /* line-heightを調整 */
     flex: 1; /* 4つのボタンを均等配置 */
-    min-width: 0; /* flex縮小を許可 */
+    min-width: 45px; /* 最小幅を設定して一行表示を保証 */
+    white-space: nowrap; /* テキストの改行を防止 */
 }
 
 input[type="text"] {

--- a/index.html
+++ b/index.html
@@ -20,10 +20,10 @@
                     <input type="text" id="templateName" placeholder="テンプレート名を入力">
 
                     <div class="template-controls">
+                        <button class="btn btn-secondary" onclick="selectAllTemplates()">全☑</button>
+                        <button class="btn btn-secondary" onclick="clearAllTemplates()">解除</button>
                         <button class="btn btn-success" onclick="saveTemplate()">保存</button>
                         <button class="btn btn-danger" onclick="deleteTemplate()">削除</button>
-                        <button class="btn btn-secondary" onclick="selectAllTemplates()">一括☑</button>
-                        <button class="btn btn-secondary" onclick="clearAllTemplates()">☑解除</button>
                     </div>
 
                     <div class="template-list" id="templateList">


### PR DESCRIPTION
## Summary
- チェック系ボタンのテキストを「全☑」「解除」に短縮して一行表示
- チェック系ボタンを保存・削除ボタンの左側に配置
- white-space: nowrapとmin-width: 45pxで一行表示を保証

## Test plan
- [x] ボタンテキストの一行表示確認
- [x] ボタン配置順序の確認（全☑、解除、保存、削除）
- [x] レスポンシブ表示の確認

🤖 Generated with [Claude Code](https://claude.ai/code)