### PR TITLE
fix: メモ本文列ボタンの最適化

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -184,8 +184,18 @@ textarea:focus {
 
 .memo-controls {
     display: flex;
-    gap: 10px;
+    gap: 4px;
     margin-bottom: 15px;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.memo-controls .btn {
+    margin: 2px 0;
+    line-height: 1.2;
+    flex: 1;
+    min-width: 65px; /* メモボタン用の最小幅 */
+    white-space: nowrap;
 }
 
 .template-section h3 {

--- a/index.html
+++ b/index.html
@@ -35,9 +35,9 @@
                 <div class="date-info" id="dateInfo"></div>
 
                 <div class="memo-controls">
-                    <button class="btn btn-secondary" onclick="addDateToMemo()">📅 メモ内容に日付を付加する</button>
-                    <button class="btn btn-primary" onclick="copyToClipboard()">📋 クリップボードにコピー</button>
-                    <button class="btn btn-success" onclick="newMemo()">📝 新規メモ</button>
+                    <button class="btn btn-secondary" onclick="addDateToMemo()">📅 日付付加</button>
+                    <button class="btn btn-primary" onclick="copyToClipboard()">📋 コピー</button>
+                    <button class="btn btn-success" onclick="newMemo()">📝 新規</button>
                     <button class="btn btn-danger" onclick="clearMemo()">🗑️ クリア</button>
                 </div>
 


### PR DESCRIPTION
## Summary
- メモ本文列ボタンのテキストを短縮（「📅 日付付加」「📋 コピー」「📝 新規」「🗑️ クリア」）
- テンプレートコントロールと同様のレイアウトに統一
- flex: 1とmin-width: 65pxで均等配置とサイズ統一

## Test plan
- [x] ボタンテキストの短縮確認
- [x] 4つのボタンが均等に配置されることを確認
- [x] レスポンシブ表示の確認
- [x] 既存機能の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)