### PR TITLE
fix: テンプレート列とメモ本文列のボタン高さ統一

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -196,7 +196,8 @@ textarea:focus {
     flex: 1;
     min-width: 75px; /* 「📅 日付付加」が1行表示されるよう最小幅を調整 */
     white-space: nowrap;
-    font-size: 14px; /* フォントサイズを微調整 */
+    font-size: 14px;
+    padding: 8px 12px; /* テンプレート列と高さを合わせるためパディング調整 */
 }
 
 .template-section h3 {
@@ -443,6 +444,8 @@ textarea:focus {
     flex: 1; /* 4つのボタンを均等配置 */
     min-width: 45px; /* 最小幅を設定して一行表示を保証 */
     white-space: nowrap; /* テキストの改行を防止 */
+    font-size: 14px; /* メモ列と統一 */
+    padding: 8px 12px; /* メモ列と高さを合わせるためパディング調整 */
 }
 
 input[type="text"] {


### PR DESCRIPTION
## Summary
- 両列のボタンのfont-sizeを14pxに統一
- 両列のボタンのpaddingを8px 12pxに統一
- ボタンの高さが揃い、体裁の違和感を解消

## Test plan
- [x] テンプレート列とメモ本文列のボタン高さが同じことを確認
- [x] レスポンシブ表示での確認
- [x] 既存機能の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)