### PR TITLE
fix: メモ本文列に見出し追加で高さバランス調整

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -202,7 +202,8 @@ textarea:focus {
     min-height: auto !important; /* 高さ自動調整 */
 }
 
-.template-section h3 {
+.template-section h3,
+.memo-area h3 {
     margin-top: 0;
     margin-bottom: 15px;
     color: var(--primary-purple-dark);

--- a/index.html
+++ b/index.html
@@ -32,6 +32,7 @@
             </div>
 
             <div class="memo-area">
+                <h3>メモ本文</h3>
                 <div class="date-info" id="dateInfo"></div>
 
                 <div class="memo-controls">


### PR DESCRIPTION
## Summary
- メモ本文列に「メモ本文」見出し（h3）を追加
- テンプレート列と同じスタイルを適用して統一感を向上
- 列間の高さバランスを調整してUIの統一感を向上

## Before/After
**Before**: テンプレート列のみに見出しがあり、メモ本文列との高さバランスが悪い
**After**: 両列に統一された見出しがあり、高さバランスが改善

## Test plan
- [x] メモ本文列に「メモ本文」見出しが表示されることを確認
- [x] テンプレート列と同じスタイルで表示されることを確認
- [x] 列間のバランスが改善されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)