### PR TITLE
fix: 選択済みテンプレートのフォントサイズ統一

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -622,7 +622,7 @@ input[type="text"]:focus {
     }
 
     .template-box-header {
-        font-size: var(--large-font-size);
+        font-size: 16px !important; /* 他のテンプレート名と統一 */
         margin-bottom: 12px;
     }
 


### PR DESCRIPTION
## Summary
- モバイル表示でのtemplate-box-headerのフォントサイズを16pxに統一
- 他のテンプレート名表示と同じサイズになり、統一感を向上
- `!important`でCSS変数による上書きを防止

## Before/After
**Before**: モバイル表示で18px（--large-font-size）が適用され、他より大きく表示
**After**: 全画面サイズで16pxに統一され、テンプレート名と同じサイズ

## Test plan
- [x] 選択済みテンプレートボックスのヘッダーが16pxで表示されることを確認
- [x] テンプレート列のテンプレート名と同じサイズになることを確認
- [x] 全画面サイズでの統一性確認

🤖 Generated with [Claude Code](https://claude.ai/code)