### PR TITLE
fix: 日付表示エリアとテンプレート名入力欄のサイズ統一

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -469,13 +469,14 @@ input[type="text"]:focus {
 
 .date-info {
     text-align: center;
-    padding: 12px;
-    background: var(--light-purple);
-    border-radius: 12px;
-    margin-bottom: 15px;
+    padding: 10px 14px; /* テンプレート名入力欄と同じパディング */
+    background: rgba(255, 255, 255, 0.8); /* テンプレート名入力欄と同じ背景 */
+    border-radius: 8px; /* テンプレート名入力欄と同じ角丸 */
+    margin-bottom: 10px; /* テンプレート名入力欄と同じマージン */
     font-weight: 600;
-    color: var(--primary-purple-dark);
-    border: 1px solid var(--border-purple);
+    font-size: 14px; /* テンプレート名入力欄と同じフォントサイズ */
+    color: var(--text-dark); /* テンプレート名入力欄と同じ文字色 */
+    border: 2px solid var(--border-purple); /* テンプレート名入力欄と同じボーダー */
 }
 
 /* スマートフォン（シニア対応強化） */


### PR DESCRIPTION
## Summary
- 日付表示エリアのスタイルをテンプレート名入力欄と統一
- padding、margin、border、background、font-sizeを同じ値に調整
- 視覚的な統一感を向上し、列間のバランスを改善

## Before/After
**Before**: 日付表示エリアが独自のスタイルで、テンプレート名入力欄と異なる見た目
**After**: 両要素が同じサイズ・スタイルで統一され、整理された見た目

## Test plan
- [x] 日付表示エリアとテンプレート名入力欄が同じサイズになることを確認
- [x] レスポンシブ表示での確認
- [x] 統一感の向上確認

🤖 Generated with [Claude Code](https://claude.ai/code)