### PR TITLE
refactor: サイズ統一とスタイル分離の改善

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -450,11 +450,6 @@ textarea:focus {
 
 input[type="text"] {
     width: 100%;
-    padding: 10px 14px;
-    border: 2px solid var(--border-purple);
-    border-radius: 8px;
-    margin-bottom: 10px;
-    font-size: 14px;
     background: rgba(255, 255, 255, 0.8);
     color: var(--text-dark);
     transition: all 0.3s ease;
@@ -467,16 +462,20 @@ input[type="text"]:focus {
     background: rgba(255, 255, 255, 1);
 }
 
+/* サイズ統一用の共通クラス */
+.uniform-input-size {
+    padding: 10px 14px;
+    border-radius: 8px;
+    margin-bottom: 10px;
+    font-size: 14px;
+    border: 2px solid var(--border-purple);
+}
+
 .date-info {
     text-align: center;
-    padding: 10px 14px; /* テンプレート名入力欄と同じパディング */
-    background: rgba(255, 255, 255, 0.8); /* テンプレート名入力欄と同じ背景 */
-    border-radius: 8px; /* テンプレート名入力欄と同じ角丸 */
-    margin-bottom: 10px; /* テンプレート名入力欄と同じマージン */
+    background: var(--light-purple); /* 元の色に戻す */
     font-weight: 600;
-    font-size: 14px; /* テンプレート名入力欄と同じフォントサイズ */
-    color: var(--text-dark); /* テンプレート名入力欄と同じ文字色 */
-    border: 2px solid var(--border-purple); /* テンプレート名入力欄と同じボーダー */
+    color: var(--primary-purple-dark); /* 元の色に戻す */
 }
 
 /* スマートフォン（シニア対応強化） */

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
                 <div class="template-section">
                     <h3>テンプレート</h3>
 
-                    <input type="text" id="templateName" placeholder="テンプレート名を入力">
+                    <input type="text" id="templateName" class="uniform-input-size" placeholder="テンプレート名を入力">
 
                     <div class="template-controls">
                         <button class="btn btn-secondary" onclick="selectAllTemplates()">全☑</button>
@@ -33,7 +33,7 @@
 
             <div class="memo-area">
                 <h3>メモ本文</h3>
-                <div class="date-info" id="dateInfo"></div>
+                <div class="date-info uniform-input-size" id="dateInfo"></div>
 
                 <div class="memo-controls">
                     <button class="btn btn-secondary" onclick="addDateToMemo()">📅 日付付加</button>


### PR DESCRIPTION
## Summary
- `.uniform-input-size`共通クラスを新規作成してサイズ統一を管理
- 日付表示エリアの色を元の紫系に戻す（背景: var(--light-purple)、文字: var(--primary-purple-dark)）
- CSSを分離してメンテナンス性向上

## Before/After
**Before**: 日付表示エリアとテンプレート名入力欄で重複したスタイル定義
**After**: 共通クラスでサイズ統一、個別の色スタイルは各要素で管理

## Technical improvements
- CSSの重複を削減
- 保守性向上（サイズ変更時は1箇所修正のみ）
- 色とサイズの責務分離

## Test plan
- [x] 日付表示エリアが元の紫色で表示されることを確認
- [x] テンプレート名入力欄と同じサイズになることを確認
- [x] 共通クラスが正しく適用されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)