### PR TITLE
fix: 日付表示エリア縦サイズ統一とボタン位置整列

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -433,7 +433,7 @@ textarea:focus {
 .template-controls {
     display: flex;
     gap: 4px;
-    margin-top: 15px;
+    margin-top: 5px; /* メモコントロールと位置を揃えるため調整 */
     flex-wrap: wrap;
     align-items: center;
 }
@@ -476,6 +476,8 @@ input[type="text"]:focus {
     background: var(--light-purple); /* 元の色に戻す */
     font-weight: 600;
     color: var(--primary-purple-dark); /* 元の色に戻す */
+    line-height: 1.2; /* テンプレート名入力欄と同じline-height */
+    min-height: 20px; /* 内容の高さを確保 */
 }
 
 /* スマートフォン（シニア対応強化） */


### PR DESCRIPTION
## Summary
- 日付表示エリアにline-height: 1.2とmin-height: 20pxを追加してテンプレート名入力欄と同じ縦サイズに
- テンプレートコントロールのmargin-topを15pxから5pxに調整してメモコントロールと位置を整列
- 列間のボタン位置が水平に揃い、視覚的バランスが向上

## Before/After
**Before**: 日付表示エリアとテンプレート名入力欄で微妙な高さの違い、ボタン位置がずれている
**After**: 同じ縦サイズ、ボタンが水平に整列された統一感のあるレイアウト

## Test plan
- [x] 日付表示エリアとテンプレート名入力欄が同じ縦サイズになることを確認
- [x] テンプレート列とメモ本文列のボタンが水平に整列することを確認
- [x] レスポンシブ表示での確認

🤖 Generated with [Claude Code](https://claude.ai/code)