### PR TITLE
fix: ボタンとテキストエリアの精密な水平整列

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -212,6 +212,7 @@ textarea:focus {
     border: 2px solid var(--border-purple);
     border-radius: 12px;
     background: rgba(255, 255, 255, 0.9);
+    margin-top: 15px; /* メモテキストエリアと位置を合わせる */
 }
 
 .template-item {
@@ -433,7 +434,7 @@ textarea:focus {
 .template-controls {
     display: flex;
     gap: 4px;
-    margin-top: 5px; /* メモコントロールと位置を揃えるため調整 */
+    margin-top: 0px; /* メモコントロールと位置を完全に揃える */
     flex-wrap: wrap;
     align-items: center;
 }


### PR DESCRIPTION
## Summary
- テンプレートコントロールのmargin-topを0pxに調整してメモコントロールと完全に水平整列
- テンプレートリストにmargin-top: 15pxを追加してメモテキストエリアと開始位置を揃える
- 列間の要素が正確に水平に並び、視覚的バランスが完璧に

## Before/After
**Before**: テンプレート列のボタンが若干低く、テキストエリアの開始位置もずれている
**After**: ボタンもテキストエリアも完全に水平整列された整理されたレイアウト

## Test plan
- [x] テンプレート列とメモ本文列のボタンが完全に水平に整列することを確認
- [x] テンプレートリストとメモテキストエリアの開始位置が揃うことを確認
- [x] レスポンシブ表示での確認

🤖 Generated with [Claude Code](https://claude.ai/code)