### PR TITLE
fix: テンプレート保存・削除時の選択済みテンプレート自動更新

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -429,16 +429,20 @@ function deleteTemplateFromBox(templateName) {
 function saveTemplate() {
     const name = document.getElementById('templateName').value.trim();
     const content = document.getElementById('memoText').value;
-    
+
     if (!name) {
         alert('テンプレート名を入力してください');
         return;
     }
-    
+
     templates[name] = content;
     saveTemplates();
     selectedTemplate = name;
     renderTemplateList();
+
+    // 選択済みテンプレートボックスも更新する
+    renderSelectedTemplateBoxes();
+
     alert('テンプレートを保存しました: ' + name);
 }
 
@@ -447,18 +451,27 @@ function deleteTemplate() {
         alert('削除するテンプレートを選択してください');
         return;
     }
-    
+
     const templateName = selectedTemplate;
     showSeniorConfirmDialog(
         `テンプレート「${templateName}」を削除しますか？\n\nこの操作は取り消すことができません。`,
         () => {
             // 削除実行
             delete templates[templateName];
+
+            // 選択状態からも削除
+            selectedTemplates.delete(templateName);
+
             saveTemplates();
+            saveSelectedTemplates();
             selectedTemplate = null;
             document.getElementById('templateName').value = '';
             document.getElementById('memoText').value = '';
             renderTemplateList();
+
+            // 選択済みテンプレートボックスも更新する
+            renderSelectedTemplateBoxes();
+
             alert('テンプレートを削除しました');
         },
         () => {


### PR DESCRIPTION
## Summary
- saveTemplate()関数にrenderSelectedTemplateBoxes()の呼び出しを追加
- deleteTemplate()関数でも選択状態の削除とボックス更新を追加
- テンプレート保存・削除時に選択済みテンプレートボックスが最新内容で自動更新される

## Problem solved
選択済みテンプレートが表示されている状態でメモ本文を更新して保存すると、選択済みテンプレートが更新前のままの状態になる問題を解決

## Before/After
**Before**: テンプレート保存後も選択済みテンプレートボックスは古い内容のまま
**After**: テンプレート保存・削除時に選択済みテンプレートボックスが最新内容に自動更新

## Test plan
- [x] テンプレートを選択して表示
- [x] メモ本文を編集してテンプレート保存
- [x] 選択済みテンプレートボックスが最新内容に更新されることを確認
- [x] テンプレート削除時の動作確認

🤖 Generated with [Claude Code](https://claude.ai/code)